### PR TITLE
Updated SpineGameObject type definition

### DIFF
--- a/types/SpineGameObject.d.ts
+++ b/types/SpineGameObject.d.ts
@@ -98,7 +98,7 @@ declare class SpineGameObject extends Phaser.GameObjects.GameObject implements O
     setScale(x: number, y?: number): this;
     setScrollFactor(x: number, y?: number): this;
     setSize(width?: number, height?: number, offsetX?: number, offsetY?: number): SpineGameObject;
-    setSkeleton(atlasDataKey: string, skeletonJSON: object, animationName?: string, loop?: boolean): SpineGameObject;
+    setSkeleton(atlasDataKey: string, animationName?: string, loop?: boolean, skeletonJSON?: object): SpineGameObject;
     setSkeletonFromJSON(atlasDataKey: string, skeletonJSON: object, animationName?: string, loop?: boolean): SpineGameObject;
     setSkin(newSkin: spine.Skin): SpineGameObject;
     setSkinByName(skinName: string): SpineGameObject;


### PR DESCRIPTION
This PR 

* Fixes a bug

Describe the changes below:
The type exposed in the definition file does not correspond to the source code, which makes it incompatible. This PR fixes that.

